### PR TITLE
Anonymous matches in clauses

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,20 @@ The columns here are filename, row, column, match name, and match text.
 Note, however, that if your query includes a match with newlines in the text they will be included in the output!
 If this causes problems for your use case, try asking for JSON output (`-f json`) instead.
 
-`tree-grepper` uses [Tree-sitter's s-expressions](https://tree-sitter.github.io/tree-sitter/using-parsers#pattern-matching-with-queries) to find matches.
-See the docs there for what all you can do with it.
+`tree-grepper` uses Tree-sitter's s-expressions to find matches.
+See [the tree-sitter docs on queries](https://tree-sitter.github.io/tree-sitter/using-parsers#pattern-matching-with-queries) for what all you can do there.
 
-You can get more info (the match end and the node kind) by asking for JSON output with `-f json`.
-This is handy for discovery: if you just need node names for your language, try something like `tree-grepper -q rust '(_)' -f json`.
+We add one important thing on top of the standard query stuff (including `#eq?` and `#match?`): if you name a pattern starting with an underscore, it will not be returned in the output.
+This is primarily useful for filtering out matches you don't really care about.
+For example, to match JavaScript calls to `require` but not other functions, you could do this:
+
+```
+(call_expression (identifier)@_fn (arguments . (string)@import .) (#eq? @_fn require))
+```
+
+In addition to text output, we support JSON output for scripting: just  specify `-f json`.
+You also get more info (the match's end location and node kind) by asking for JSON output.
+This is handy for discovery: if you want to see the node names for your target language, try something like `tree-grepper -q rust '(_)' -f json`, replacing `rust` with the language of your choice.
 
 ## Supported Languages
 

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -67,11 +67,9 @@ impl Extractor {
             // that so we know it's always a language error. Buuuut we also
             // always set the language above so if this happens we also know
             // it's an internal error.
-            .with_context(|| {
-                format!(
-                    "could not parse to a tree. This is an internal error and should be reported.",
-                )
-            })?;
+            .context(
+                "could not parse to a tree. This is an internal error and should be reported.",
+            )?;
 
         let mut cursor = QueryCursor::new();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,11 @@ fn try_main(args: Vec<String>, mut out: impl Write) -> Result<()> {
                 .map(|extractor| (entry, extractor))
         })
         .map_init(Parser::new, |parser, (entry, extractor)| {
-            extractor.extract_from_file(entry.path(), parser)
+            extractor
+                .extract_from_file(entry.path(), parser)
+                .with_context(|| {
+                    format!("could not extract matches from {}", entry.path().display())
+                })
         })
         .filter_map(|result_containing_option| match result_containing_option {
             Ok(None) => None,


### PR DESCRIPTION
A query like this should result in extracting `import` but not `_fn`. However, `_fn` should still used in the `#eq?` clause.

```lisp
(call_expression (identifier)@_fn (arguments . (string)@import .) (#eq? @_fn require))
```

This didn't happen before because we were disabling everything that started with `_`, meaning it didn't make it to the filtering step within tree-sitter. In other words, that `#eq?` was never called! Oops!

This fixes that!