### PR TITLE
Add `.multiple_occurrences(true)` to `-q`

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -66,6 +66,7 @@ impl Invocation {
                     .conflicts_with("languages")
                     .conflicts_with("show-tree")
                     .multiple_values(true)
+                    .multiple_occurrences(true)
             )
             .arg(
                 Arg::new("no-gitignore")


### PR DESCRIPTION
Allow passing `-q <LANGUAGE> <QUERY>` multiple times.