### PR TITLE
Simplify langauge inclusion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,6 +368,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 
 [[package]]
+name = "paste"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,6 +565,7 @@ dependencies = [
  "ignore",
  "insta",
  "itertools",
+ "paste",
  "rayon",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ rayon = "1.5.3"
 serde = { version = "1.0.139", features = [ "derive" ] }
 serde_json = "1.0.82"
 tree-sitter = "0.20.8"
+paste = "1.0.7"
 
 [dev-dependencies]
 insta = "1.15.0"

--- a/build.rs
+++ b/build.rs
@@ -1,201 +1,44 @@
 use std::path::PathBuf;
 
+fn build_langs(langs: &[(&str, Option<&str>, &[(&str, bool)])]) {
+    for (lang, subdir, files) in langs {
+        let mut dir = PathBuf::new();
+        let repo_name = format!("tree-sitter-{}", lang);
+        dir.push("vendor");
+        dir.push(&repo_name);
+        if let Some(subdir) = subdir {
+            dir.push(subdir);
+        }
+        dir.push("src");
+        for (file, cpp) in *files {
+            let loc = dir.join(file);
+            println!("cargo:rerun-if-changed={}", loc.display());
+            cc::Build::new()
+                .include(&dir)
+                .warnings(false)
+                .cpp(*cpp)
+                .file(loc)
+                .compile(&format!("{}_{}", repo_name, file));
+        }
+    }
+}
+
 // https://doc.rust-lang.org/cargo/reference/build-scripts.html
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
-    // cpp
-    let cpp_dir: PathBuf = ["vendor", "tree-sitter-cpp", "src"].iter().collect();
-
-    println!("cargo:rerun-if-changed=vendor/tree-sitter-cpp/src/parser.c");
-    cc::Build::new()
-        .include(&cpp_dir)
-        .warnings(false)
-        .file(cpp_dir.join("parser.c"))
-        .compile("tree-sitter-cpp");
-
-    println!("cargo:rerun-if-changed=vendor/tree-sitter-cpp/src/scanner.cc");
-    cc::Build::new()
-        .include(&cpp_dir)
-        .cpp(true)
-        .warnings(false)
-        .file(cpp_dir.join("scanner.cc"))
-        .compile("tree_sitter_cpp_scanner");
-
-    // elixir
-    let elixir_dir: PathBuf = ["vendor", "tree-sitter-elixir", "src"].iter().collect();
-
-    println!("cargo:rerun-if-changed=vendor/tree-sitter-elixir/src/parser.c");
-    cc::Build::new()
-        .include(&elixir_dir)
-        .warnings(false)
-        .file(elixir_dir.join("parser.c"))
-        .compile("tree-sitter-elixir");
-
-    println!("cargo:rerun-if-changed=vendor/tree-sitter-elixir/src/scanner.cc");
-    cc::Build::new()
-        .include(&elixir_dir)
-        .warnings(false)
-        .cpp(true)
-        .file(elixir_dir.join("scanner.cc"))
-        .compile("tree_sitter_elixir_scanner");
-
-    // elm
-    let elm_dir: PathBuf = ["vendor", "tree-sitter-elm", "src"].iter().collect();
-
-    println!("cargo:rerun-if-changed=vendor/tree-sitter-elm/src/parser.c");
-    cc::Build::new()
-        .include(&elm_dir)
-        .warnings(false)
-        .file(elm_dir.join("parser.c"))
-        .compile("tree-sitter-elm");
-
-    println!("cargo:rerun-if-changed=vendor/tree-sitter-elm/src/scanner.cc");
-    cc::Build::new()
-        .include(&elm_dir)
-        .cpp(true)
-        .warnings(false)
-        .file(elm_dir.join("scanner.cc"))
-        .compile("tree_sitter_elm_scanner");
-
-    // haskell
-    let haskell_dir: PathBuf = ["vendor", "tree-sitter-haskell", "src"].iter().collect();
-
-    println!("cargo:rerun-if-changed=vendor/tree-sitter-haskell/src/parser.c");
-    cc::Build::new()
-        .include(&haskell_dir)
-        .warnings(false)
-        .file(haskell_dir.join("parser.c"))
-        .compile("tree-sitter-haskell");
-
-    println!("cargo:rerun-if-changed=vendor/tree-sitter-haskell/src/scanner.cc");
-    cc::Build::new()
-        .include(&haskell_dir)
-        .warnings(false)
-        .file(haskell_dir.join("scanner.c"))
-        .compile("tree_sitter_haskell_scanner");
-
-    // javascript
-    let javascript_dir: PathBuf = ["vendor", "tree-sitter-javascript", "src"].iter().collect();
-
-    println!("cargo:rerun-if-changed=vendor/tree-sitter-javascript/src/parser.c");
-    cc::Build::new()
-        .include(&javascript_dir)
-        .warnings(false)
-        .file(javascript_dir.join("parser.c"))
-        .compile("tree-sitter-javascript");
-
-    println!("cargo:rerun-if-changed=vendor/tree-sitter-javascript/src/scanner.c");
-    cc::Build::new()
-        .include(&javascript_dir)
-        .warnings(false)
-        .file(javascript_dir.join("scanner.c"))
-        .compile("tree_sitter_javascript_scanner");
-
-    // markdown
-    let markdown_dir: PathBuf = ["vendor", "tree-sitter-markdown", "src"].iter().collect();
-
-    println!("cargo:rerun-if-changed=vendor/tree-sitter-markdown/src/parser.c");
-    cc::Build::new()
-        .include(&markdown_dir)
-        .warnings(false)
-        .file(markdown_dir.join("parser.c"))
-        .compile("tree-sitter-markdown");
-
-    println!("cargo:rerun-if-changed=vendor/tree-sitter-markdown/src/scanner.cc");
-    cc::Build::new()
-        .include(&markdown_dir)
-        .cpp(true)
-        .warnings(false)
-        .file(markdown_dir.join("scanner.cc"))
-        .compile("tree_sitter_markdown_scanner");
-
-    // nix
-    let nix_dir: PathBuf = ["vendor", "tree-sitter-nix", "src"].iter().collect();
-
-    println!("cargo:rerun-if-changed=vendor/tree-sitter-nix/src/parser.c");
-    cc::Build::new()
-        .include(&nix_dir)
-        .warnings(false)
-        .file(nix_dir.join("parser.c"))
-        .compile("tree-sitter-nix");
-
-    println!("cargo:rerun-if-changed=vendor/tree-sitter-nix/src/scanner.c");
-    cc::Build::new()
-        .include(&nix_dir)
-        .warnings(false)
-        .file(nix_dir.join("scanner.c"))
-        .compile("tree_sitter_nix_scanner");
-
-    // php
-    let php_dir: PathBuf = ["vendor", "tree-sitter-php", "src"].iter().collect();
-
-    println!("cargo:rerun-if-changed=vendor/tree-sitter-php/src/parser.c");
-    cc::Build::new()
-        .include(&php_dir)
-        .warnings(false)
-        .file(php_dir.join("parser.c"))
-        .compile("tree-sitter-php");
-
-    println!("cargo:rerun-if-changed=vendor/tree-sitter-php/src/scanner.cc");
-    cc::Build::new()
-        .include(&php_dir)
-        .cpp(true)
-        .warnings(false)
-        .file(php_dir.join("scanner.cc"))
-        .compile("tree_sitter_php_scanner");
-
-    // ruby
-    let ruby_dir: PathBuf = ["vendor", "tree-sitter-ruby", "src"].iter().collect();
-
-    println!("cargo:rerun-if-changed=vendor/tree-sitter-ruby/src/parser.c");
-    cc::Build::new()
-        .include(&ruby_dir)
-        .warnings(false)
-        .file(ruby_dir.join("parser.c"))
-        .compile("tree-sitter-ruby");
-
-    println!("cargo:rerun-if-changed=vendor/tree-sitter-ruby/src/scanner.cc");
-    cc::Build::new()
-        .include(&ruby_dir)
-        .cpp(true)
-        .warnings(false)
-        .file(ruby_dir.join("scanner.cc"))
-        .compile("tree_sitter_ruby_scanner");
-
-    // rust
-    let rust_dir: PathBuf = ["vendor", "tree-sitter-rust", "src"].iter().collect();
-
-    println!("cargo:rerun-if-changed=vendor/tree-sitter-rust/src/parser.c");
-    cc::Build::new()
-        .include(&rust_dir)
-        .warnings(false)
-        .file(rust_dir.join("parser.c"))
-        .compile("tree-sitter-rust");
-
-    println!("cargo:rerun-if-changed=vendor/tree-sitter-rust/src/scanner.c");
-    cc::Build::new()
-        .include(&rust_dir)
-        .warnings(false)
-        .file(rust_dir.join("scanner.c"))
-        .compile("tree_sitter_rust_scanner");
-
-    // typescript
-    let typescript_dir: PathBuf = ["vendor", "tree-sitter-typescript", "typescript", "src"]
-        .iter()
-        .collect();
-
-    println!("cargo:rerun-if-changed=vendor/tree-sitter-typescript/typescript/src/parser.c");
-    cc::Build::new()
-        .include(&typescript_dir)
-        .warnings(false)
-        .file(typescript_dir.join("parser.c"))
-        .compile("tree-sitter-typescript");
-
-    println!("cargo:rerun-if-changed=vendor/tree-sitter-typescript/typescript/src/scanner.c");
-    cc::Build::new()
-        .include(&typescript_dir)
-        .warnings(false)
-        .file(typescript_dir.join("scanner.c"))
-        .compile("tree_sitter_typescript_scanner");
+    build_langs(&[
+        ("cpp", None, &[("parser.c", false), ("scanner.cc", true)]),
+        ("elixir", None, &[("parser.c", false), ("scanner.cc", true)]),
+        ("elm", None, &[("parser.c", false), ("scanner.cc", true)]),
+        ("haskell", None, &[("parser.c", false), ("scanner.c", false)]),
+        ("javascript", None, &[("parser.c", false), ("scanner.c", false)]),
+        ("markdown", None, &[("parser.c", false), ("scanner.cc", true)]),
+        ("nix", None, &[("parser.c", false), ("scanner.c", false)]),
+        ("php", None, &[("parser.c", false), ("scanner.cc", true)]),
+        ("ruby", None, &[("parser.c", false), ("scanner.cc", true)]),
+        ("python", None, &[("parser.c", false), ("scanner.cc", false)]),
+        ("rust", None, &[("parser.c", false), ("scanner.c", false)]),
+        ("typescript", Some("typescript"), &[("parser.c", false), ("scanner.c", false)]),
+    ]);
 }


### PR DESCRIPTION
Not entirely sure how useful this is, but did some simple automation so that including languages become less tedious. Obviously this is not as useful as runtime loading (#88) but would easily make it easier to add/remove language support. This adds the `paste` crate for transforming the langauge names/strings

Note: I didn't actually build the whole thing, but only a version including only Rust, C, C++ and Python. The setup for other languages should be exactly the same, but I could have made mistakes during the conversion