### PR TITLE
Feature: add java support

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ For example:
 - Elixir
 - Elm
 - Haskell
+- Java
 - JavaScript
 - Markdown
 - PHP

--- a/build.rs
+++ b/build.rs
@@ -85,6 +85,16 @@ fn main() {
         .file(haskell_dir.join("scanner.c"))
         .compile("tree_sitter_haskell_scanner");
 
+    // java
+    let java_dir: PathBuf = ["vendor", "tree-sitter-java", "src"].iter().collect();
+
+    println!("cargo:rerun-if-changed=vendor/tree-sitter-java/src/parser.c");
+    cc::Build::new()
+        .include(&java_dir)
+        .warnings(false)
+        .file(java_dir.join("parser.c"))
+        .compile("tree-sitter-java");
+
     // javascript
     let javascript_dir: PathBuf = ["vendor", "tree-sitter-javascript", "src"].iter().collect();
 

--- a/flake.lock
+++ b/flake.lock
@@ -61,6 +61,7 @@
         "tree-sitter-elixir": "tree-sitter-elixir",
         "tree-sitter-elm": "tree-sitter-elm",
         "tree-sitter-haskell": "tree-sitter-haskell",
+        "tree-sitter-java": "tree-sitter-java",
         "tree-sitter-javascript": "tree-sitter-javascript",
         "tree-sitter-markdown": "tree-sitter-markdown",
         "tree-sitter-nix": "tree-sitter-nix",
@@ -150,6 +151,22 @@
       "original": {
         "owner": "tree-sitter",
         "repo": "tree-sitter-haskell",
+        "type": "github"
+      }
+    },
+    "tree-sitter-java": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1674849453,
+        "narHash": "sha256-JeQZ4TMpt6Lfbcfc6m/PzhFZEgTdouasJ3b1sPISy2s=",
+        "owner": "tree-sitter",
+        "repo": "tree-sitter-java",
+        "rev": "dd597f13eb9bab0c1bccc9aec390e8e6ebf9e0a6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tree-sitter",
+        "repo": "tree-sitter-java",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -70,6 +70,11 @@
       url = "github:tree-sitter/tree-sitter-typescript";
       flake = false;
     };
+
+    tree-sitter-java = {
+      url = "github:tree-sitter/tree-sitter-java";
+      flake = false;
+    };
   };
 
   outputs = inputs:
@@ -91,6 +96,7 @@
           ln -s ${inputs.tree-sitter-elixir} vendor/tree-sitter-elixir
           ln -s ${inputs.tree-sitter-elm} vendor/tree-sitter-elm
           ln -s ${inputs.tree-sitter-haskell} vendor/tree-sitter-haskell
+          ln -s ${inputs.tree-sitter-java} vendor/tree-sitter-java
           ln -s ${inputs.tree-sitter-javascript} vendor/tree-sitter-javascript
           ln -s ${inputs.tree-sitter-markdown} vendor/tree-sitter-markdown
           ln -s ${inputs.tree-sitter-php} vendor/tree-sitter-php

--- a/src/language.rs
+++ b/src/language.rs
@@ -11,6 +11,7 @@ pub enum Language {
     Elixir,
     Elm,
     Haskell,
+    Java,
     JavaScript,
     Markdown,
     Nix,
@@ -34,6 +35,7 @@ impl Language {
                 Language::Elixir => tree_sitter_elixir(),
                 Language::Elm => tree_sitter_elm(),
                 Language::Haskell => tree_sitter_haskell(),
+                Language::Java => tree_sitter_java(),
                 Language::JavaScript => tree_sitter_javascript(),
                 Language::Markdown => tree_sitter_markdown(),
                 Language::Nix => tree_sitter_nix(),
@@ -57,6 +59,7 @@ impl Language {
             Language::Elixir => "elixir",
             Language::Elm => "elm",
             Language::Haskell => "haskell",
+            Language::Java => "java",
             Language::JavaScript => "js",
             Language::Markdown => "markdown",
             Language::Nix => "nix",
@@ -137,6 +140,7 @@ extern "C" {
     fn tree_sitter_elixir() -> tree_sitter::Language;
     fn tree_sitter_elm() -> tree_sitter::Language;
     fn tree_sitter_haskell() -> tree_sitter::Language;
+    fn tree_sitter_java() -> tree_sitter::Language;
     fn tree_sitter_javascript() -> tree_sitter::Language;
     fn tree_sitter_markdown() -> tree_sitter::Language;
     fn tree_sitter_nix() -> tree_sitter::Language;


### PR DESCRIPTION
This PR adds support for Java.

This is a language that does not have an external scanner (so there is no `scanner.c`/`scanner.cc`). It still works according to my initial testing, i.e. adding a file `foo.java`:

```java
class Foo {
  void bar() {
    int a = 10;
  }
}
```

and running

```
$ tree-grepper --query java '(identifier)' foo.java
./foo.java:1:7:foo:Foo
./foo.java:2:8:foo:bar
./foo.java:3:9:foo:a
```

I don't know if any more is required regarding testing, but this quick test works.
