### PR TITLE
Feature: add go support

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -68,6 +68,16 @@ fn main() {
         .file(elm_dir.join("scanner.cc"))
         .compile("tree_sitter_elm_scanner");
 
+    // go
+    let go_dir: PathBuf = ["vendor", "tree-sitter-go", "src"].iter().collect();
+
+    println!("cargo:rerun-if-changed=vendor/tree-sitter-go/src/parser.c");
+    cc::Build::new()
+        .include(&go_dir)
+        .warnings(false)
+        .file(go_dir.join("parser.c"))
+        .compile("tree-sitter-go");
+
     // haskell
     let haskell_dir: PathBuf = ["vendor", "tree-sitter-haskell", "src"].iter().collect();
 

--- a/flake.lock
+++ b/flake.lock
@@ -60,6 +60,7 @@
         "tree-sitter-cpp": "tree-sitter-cpp",
         "tree-sitter-elixir": "tree-sitter-elixir",
         "tree-sitter-elm": "tree-sitter-elm",
+        "tree-sitter-go": "tree-sitter-go",
         "tree-sitter-haskell": "tree-sitter-haskell",
         "tree-sitter-javascript": "tree-sitter-javascript",
         "tree-sitter-markdown": "tree-sitter-markdown",
@@ -134,6 +135,22 @@
         "owner": "elm-tooling",
         "ref": "main",
         "repo": "tree-sitter-elm",
+        "type": "github"
+      }
+    },
+    "tree-sitter-go": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1670492714,
+        "narHash": "sha256-38pkqR9iEIEf9r3IHJPIYgKfWBlb9aQWi1kij04Vo5k=",
+        "owner": "tree-sitter",
+        "repo": "tree-sitter-go",
+        "rev": "64457ea6b73ef5422ed1687178d4545c3e91334a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tree-sitter",
+        "repo": "tree-sitter-go",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,11 @@
       flake = false;
     };
 
+    tree-sitter-go = {
+      url = "github:tree-sitter/tree-sitter-go";
+      flake = false;
+    };
+
     tree-sitter-haskell = {
       url = "github:tree-sitter/tree-sitter-haskell";
       flake = false;
@@ -90,6 +95,7 @@
           ln -s ${inputs.tree-sitter-cpp} vendor/tree-sitter-cpp
           ln -s ${inputs.tree-sitter-elixir} vendor/tree-sitter-elixir
           ln -s ${inputs.tree-sitter-elm} vendor/tree-sitter-elm
+          ln -s ${inputs.tree-sitter-go} vendor/tree-sitter-go
           ln -s ${inputs.tree-sitter-haskell} vendor/tree-sitter-haskell
           ln -s ${inputs.tree-sitter-javascript} vendor/tree-sitter-javascript
           ln -s ${inputs.tree-sitter-markdown} vendor/tree-sitter-markdown

--- a/src/language.rs
+++ b/src/language.rs
@@ -10,6 +10,7 @@ pub enum Language {
     Cpp,
     Elixir,
     Elm,
+    Go,
     Haskell,
     JavaScript,
     Markdown,
@@ -33,6 +34,7 @@ impl Language {
                 Language::Cpp => tree_sitter_cpp(),
                 Language::Elixir => tree_sitter_elixir(),
                 Language::Elm => tree_sitter_elm(),
+                Language::Go => tree_sitter_go(),
                 Language::Haskell => tree_sitter_haskell(),
                 Language::JavaScript => tree_sitter_javascript(),
                 Language::Markdown => tree_sitter_markdown(),
@@ -56,6 +58,7 @@ impl Language {
             Language::Cpp => "cpp",
             Language::Elixir => "elixir",
             Language::Elm => "elm",
+            Language::Go => "go",
             Language::Haskell => "haskell",
             Language::JavaScript => "js",
             Language::Markdown => "markdown",
@@ -136,6 +139,7 @@ extern "C" {
     fn tree_sitter_cpp() -> tree_sitter::Language;
     fn tree_sitter_elixir() -> tree_sitter::Language;
     fn tree_sitter_elm() -> tree_sitter::Language;
+    fn tree_sitter_go() -> tree_sitter::Language;
     fn tree_sitter_haskell() -> tree_sitter::Language;
     fn tree_sitter_javascript() -> tree_sitter::Language;
     fn tree_sitter_markdown() -> tree_sitter::Language;


### PR DESCRIPTION
This PR adds support for Go.

It has been tested by running on the following file:

```go
package main

func main() {
}
```

```bash
$ tree-grepper --query go '(identifier)' foo.go
./foo.go:3:6:query:main
```
