### PR TITLE
Make --languages CLI flag not require a useless argument

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -102,6 +102,7 @@ impl Invocation {
             .arg(
                 Arg::new("languages")
                     .long("languages")
+                    .action(ArgAction::SetTrue)
                     .help("print the language names tree-grepper knows about")
                     .conflicts_with("additional-query")
                     .conflicts_with("show-tree")


### PR DESCRIPTION
Fixes https://github.com/BrianHicks/tree-grepper/issues/270

`tree-grepper --languages` now works without error, and no longer shows a required argument to `--languages`.

I still can't find where this is described in the [clap documentation](https://docs.rs/clap/4.1.11/clap/index.html), but I found this as an example in the doc comment for a different function (which also seems to not be publicly documented?) https://github.com/clap-rs/clap/blob/cc1474f97c78002f3d99261699114e61d70b0634/src/builder/arg.rs#L790-L800