### PR TITLE
enable building only with Cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "git2"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0155506aab710a86160ddb504a480d2964d7ab5b9e62419be69e0032bc5931c"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +339,16 @@ checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
 dependencies = [
  "humantime",
  "serde",
+]
+
+[[package]]
+name = "idna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -384,6 +418,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.13.5+1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e5ea06c26926f1002dd553fded6cfcdc9784c1f60feeb58368b4d9b07b6dba"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b094a36eb4b8b8c8a7b4b8ae43b2944502be3e59cd87687595cf6b0a71b3f4ca"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c15da26e5af7e25c90b37a2d75cdbf940cf4a55316de9d84c679c9b8bfabf82e"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,6 +488,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "os_pipe"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,6 +514,18 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "proc-macro2"
@@ -665,6 +769,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -695,6 +814,7 @@ dependencies = [
  "cc",
  "clap",
  "crossbeam",
+ "git2",
  "ignore",
  "itertools",
  "rayon",
@@ -734,16 +854,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "url"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ tree-sitter = "0.22.6"
 
 [build-dependencies]
 cc = { version = "1.0.99", features = [ "parallel" ] }
+git2 = "0.14"
 
 [dev-dependencies]
 trycmd = "0.15.4"

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,52 @@
+extern crate git2;
+
+use git2::Repository;
+use std::path::Path;
 use std::path::PathBuf;
 
 // https://doc.rust-lang.org/cargo/reference/build-scripts.html
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
+
+    let repos = vec![
+        ("tree-sitter-c", "https://github.com/tree-sitter/tree-sitter-c"),
+        ("tree-sitter-cpp", "https://github.com/tree-sitter/tree-sitter-cpp"),
+        ("tree-sitter-cuda", "https://github.com/theHamsta/tree-sitter-cuda"),
+        ("tree-sitter-elixir", "https://github.com/elixir-lang/tree-sitter-elixir"),
+        ("tree-sitter-elm", "https://github.com/elm-tooling/tree-sitter-elm"),
+        ("tree-sitter-go", "https://github.com/tree-sitter/tree-sitter-go"),
+        ("tree-sitter-haskell", "https://github.com/tree-sitter/tree-sitter-haskell"),
+        ("tree-sitter-java", "https://github.com/tree-sitter/tree-sitter-java"),
+        ("tree-sitter-javascript", "https://github.com/tree-sitter/tree-sitter-javascript"),
+        ("tree-sitter-markdown", "https://github.com/tree-sitter-grammars/tree-sitter-markdown"),
+        ("tree-sitter-nix", "https://github.com/cstrahan/tree-sitter-nix"),
+        ("tree-sitter-php", "https://github.com/tree-sitter/tree-sitter-php"),
+        ("tree-sitter-python", "https://github.com/tree-sitter/tree-sitter-python"),
+        ("tree-sitter-ruby", "https://github.com/tree-sitter/tree-sitter-ruby"),
+        ("tree-sitter-rust", "https://github.com/tree-sitter/tree-sitter-rust"),
+        ("tree-sitter-scss", "https://github.com/serenadeai/tree-sitter-scss"),
+        ("tree-sitter-typescript", "https://github.com/tree-sitter/tree-sitter-typescript"),
+    ];
+
+
+    let vendor_dir = Path::new("vendor");
+
+    if !vendor_dir.exists() {
+        std::fs::create_dir(vendor_dir).unwrap();
+    }
+
+    for (name, url) in repos {
+        let repo_path = vendor_dir.join(name);
+        if !repo_path.exists() {
+            println!("Cloning {} into {:?}", url, repo_path);
+            match Repository::clone(url, &repo_path) {
+                Ok(_) => println!("Successfully cloned {}", url),
+                Err(e) => eprintln!("Failed to clone {}: {}", url, e),
+            }
+        } else {
+            println!("{} already exists, skipping", repo_path.display());
+        }
+    }
 
     // c
     let c_dir: PathBuf = ["vendor", "tree-sitter-c", "src"].iter().collect();


### PR DESCRIPTION
Hello! thank you for creating this awesome project, I'm finding it immensely useful and fun to use.
I tried using ast-grep many times, but I was never able to get it to work and have the query return what I want. I just tried tree-grepper and in about 10 minutes, with the help of the Tree-sitter "`:Inspect`" Playground in Neovim, which looks like this:

![Tree-sitter Inspect in Neovim ](https://github.com/BrianHicks/tree-grepper/assets/9993663/85b11450-12de-4483-b967-c308691847a2)

[...and with the help of ChatGPT to refine the tree-sitter query](https://chatgpt.com/share/f63bbdd1-8bf7-4197-99d1-c32d9b98c733), I was able to have the query return what I wanted exactly:

```json
[
  {
    "file": "mod.rs",
    "file_type": "rust",
    "matches": [
      {
        "kind": "string_content",
        "name": "string",
        "text": "lrld",
        "start": {
          "row": 1486,
          "column": 10
        },
        "end": {
          "row": 1486,
          "column": 14
        }
      },
      {
        "kind": "string_content",
        "name": "string",
        "text": "sldr",
        "start": {
          "row": 1489,
          "column": 10
        },
        "end": {
          "row": 1489,
          "column": 14
        }
      },
      {
        "kind": "string_content",
        "name": "string",
        "text": "scnl",
        "start": {
          "row": 1498,
          "column": 10
        },
        "end": {
          "row": 1498,
          "column": 14
        }
      },
      {
        "kind": "string_content",
        "name": "string",
        "text": "rpt-any",
        "start": {
          "row": 1542,
          "column": 10
        },
        "end": {
          "row": 1542,
          "column": 17
        }
      },
      "............"
]
```

The query:
```scm
(
  (match_expression
    "match"
    value: (identifier)
    body: (match_block
      "{"
      (match_arm
        pattern: (match_pattern
            (string_literal
              "\"" 
              (string_content) @string
            )
        )
      )
    )
  )
)
```

but before actually getting to try it out, I had a lot of trouble and wasted quite a lot of time trying to get to try to use it, by building it, since trying out the Nix package manager on Arch didn't work for me, it didn't install correctly and outputs something something "socket permission error" when I try to use a Nix command.

I think enabling only a Cargo build option, without Nix, would be helpful to a lot more people and would enable a lot more people to try the software. a Cargo only build would also enable you to [publish a pre-built binary to crates.io](https://doc.rust-lang.org/book/ch14-04-installing-binaries.html#:~:text=Note%20that%20you,within%20other%20programs.), so it would make installing for people even more easier.

![](https://github.com/BrianHicks/tree-grepper/assets/9993663/8af93d77-1463-4124-8469-ec68d60a3e3c)
