### PR TITLE
Adds tree-sitter-powershell

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ javascript
 markdown
 nix
 php
+powershell
 python
 ruby
 rust

--- a/build.rs
+++ b/build.rs
@@ -284,4 +284,21 @@ fn main() {
         .warnings(false)
         .file(typescript_dir.join("scanner.c"))
         .compile("tree_sitter_typescript_scanner");
+
+    // powershell
+    let powershell_dir: PathBuf = ["vendor", "tree-sitter-powershell", "src"].iter().collect();
+
+    println!("cargo:rerun-if-changed=vendor/tree-sitter-powershell/src/parser.c");
+    cc::Build::new()
+        .include(&powershell_dir)
+        .warnings(false)
+        .file(&powershell_dir.join("parser.c"))
+        .compile("tree-sitter-powershell");
+
+    println!("cargo:rerun-if-changed=vendor/tree-sitter-powershell/src/scanner.c");
+    cc::Build::new()
+        .include(&powershell_dir)
+        .warnings(false)
+        .file(&powershell_dir.join("scanner.c"))
+        .compile("tree_sitter_powershell_scanner");
 }

--- a/flake.lock
+++ b/flake.lock
@@ -71,6 +71,7 @@
         "tree-sitter-markdown": "tree-sitter-markdown",
         "tree-sitter-nix": "tree-sitter-nix",
         "tree-sitter-php": "tree-sitter-php",
+        "tree-sitter-powershell": "tree-sitter-powershell",
         "tree-sitter-python": "tree-sitter-python",
         "tree-sitter-ruby": "tree-sitter-ruby",
         "tree-sitter-rust": "tree-sitter-rust",
@@ -285,6 +286,22 @@
       "original": {
         "owner": "tree-sitter",
         "repo": "tree-sitter-php",
+        "type": "github"
+      }
+    },
+    "tree-sitter-powershell": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1717078129,
+        "narHash": "sha256-bkLdC3pedo228UDiO7ZZ2E1r3WP2aq2Ud6Ni88ulsNc=",
+        "owner": "airbus-cert",
+        "repo": "tree-sitter-powershell",
+        "rev": "6de5d48649aa7086e2a7ba72660bcabe01c8b258",
+        "type": "github"
+      },
+      "original": {
+        "owner": "airbus-cert",
+        "repo": "tree-sitter-powershell",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -90,6 +90,11 @@
       url = "github:theHamsta/tree-sitter-cuda/v0.20.3";
       flake = false;
     };
+    
+    tree-sitter-powershell = {
+      url = "github:airbus-cert/tree-sitter-powershell";
+      flake = false;
+    };
   };
 
   outputs = inputs:
@@ -123,6 +128,7 @@
           ln -s ${inputs.tree-sitter-typescript} vendor/tree-sitter-typescript
           ln -s ${inputs.tree-sitter-nix} vendor/tree-sitter-nix
           ln -s ${inputs.tree-sitter-cuda} vendor/tree-sitter-cuda
+          ln -s ${inputs.tree-sitter-powershell} vendor/tree-sitter-powershell
         '';
       in rec {
         # `nix build`

--- a/src/extractor_chooser.rs
+++ b/src/extractor_chooser.rs
@@ -15,6 +15,7 @@ impl<'extractor> ExtractorChooser<'extractor> {
         types_builder.add_defaults();
         types_builder.add_def("cuda:*.cu,*.cuh,*.hpp")?;
         types_builder.add_def("cuda:include:cpp")?;
+        types_builder.add_def("powershell:*.ps1")?;
 
         let mut names_to_extractors = HashMap::with_capacity(extractors.len());
 

--- a/src/language.rs
+++ b/src/language.rs
@@ -18,6 +18,7 @@ pub enum Language {
     Markdown,
     Nix,
     Php,
+    PowerShell,
     Python,
     Ruby,
     Rust,
@@ -45,6 +46,7 @@ impl Language {
                 Language::Markdown => tree_sitter_markdown(),
                 Language::Nix => tree_sitter_nix(),
                 Language::Php => tree_sitter_php(),
+                Language::PowerShell => tree_sitter_powershell(),
                 Language::Python => tree_sitter_python(),
                 Language::Ruby => tree_sitter_ruby(),
                 Language::Rust => tree_sitter_rust(),
@@ -77,6 +79,7 @@ impl Language {
             Language::Rust => "rust",
             Language::Sass => "sass",
             Language::TypeScript => "ts",
+            Language::PowerShell => "powershell",
         }
     }
 }
@@ -112,6 +115,7 @@ extern "C" {
     fn tree_sitter_markdown() -> tree_sitter::Language;
     fn tree_sitter_nix() -> tree_sitter::Language;
     fn tree_sitter_php() -> tree_sitter::Language;
+    fn tree_sitter_powershell() -> tree_sitter::Language;
     fn tree_sitter_python() -> tree_sitter::Language;
     fn tree_sitter_ruby() -> tree_sitter::Language;
     fn tree_sitter_rust() -> tree_sitter::Language;

--- a/tests/cmd/languages.trycmd
+++ b/tests/cmd/languages.trycmd
@@ -12,6 +12,7 @@ javascript
 markdown
 nix
 php
+powershell
 python
 ruby
 rust


### PR DESCRIPTION
This adds the tree-sitter-powershell grammar, which is actively maintained. This is my first time dealing with nix packages, but I followed the existing code examples and I think things are done correctly, unless you want to pin a specific tagged version.